### PR TITLE
[ODS-5364] Rename appsettings.development.json files to appsettings.Development.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ packages/
 *.nupkg
 
 # AppSettings
-appsettings.development.json
+appsettings.Development.json
 appsettings.user.json
 
 # nDevConfig


### PR DESCRIPTION
Remove redundant entry from .gitignore commit message is incorrect.  In this case, it is keeping the entry but updating the value to appsettings.Development.json