### PR TITLE
ODS-5647 - Rename Clean function in build script to resolve error

### DIFF
--- a/build.githubactions.ps1
+++ b/build.githubactions.ps1
@@ -7,7 +7,7 @@
 param(
     # Command to execute, defaults to "Build".
     [string]
-    [ValidateSet("Clean", "Build", "Test", "Pack", "Publish", "CheckoutBranch")]
+    [ValidateSet("DotnetClean", "Build", "Test", "Pack", "Publish", "CheckoutBranch")]
     $Command = "Build",
 
     [switch] $SelfContained,
@@ -115,7 +115,7 @@ function Invoke-Main {
     }
 }
 
-function Clean {
+function DotnetClean {
     Invoke-Execute { dotnet clean $Solution -c $Configuration --nologo -v minimal }
 }
 
@@ -209,7 +209,7 @@ function CheckoutBranch {
 
 function Invoke-Build {
     Write-Host "Building Version $version" -ForegroundColor Cyan
-    Invoke-Step { Clean }
+    Invoke-Step { DotnetClean }
     Invoke-Step { Compile }
 }
 
@@ -231,7 +231,7 @@ function Invoke-CheckoutBranch {
 
 Invoke-Main {
     switch ($Command) {
-        Clean { Invoke-Clean }
+        DotnetClean { Invoke-DotnetClean }
         Build { Invoke-Build }
         Test { Invoke-Tests }
         Pack { Invoke-Pack }


### PR DESCRIPTION
This is to resolve a conflict with new reserved Clean keyword in PS7.3 https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#pscleanblock