### PR TITLE
ODS-5704 Install-credential-handler Step updated

### DIFF
--- a/.github/workflows/Packages - EdFi.Ods.Extensions.Homograph.yml
+++ b/.github/workflows/Packages - EdFi.Ods.Extensions.Homograph.yml
@@ -83,8 +83,37 @@ jobs:
         .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -PackageName "EdFi.Suite3.Ods.Extensions.Homograph" -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-Extensions/Extensions/EdFi.Ods.Extensions.Homograph/EdFi.Ods.Extensions.Homograph.nuspec"
       shell: pwsh
     - name: Install-credential-handler
-      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
-      shell: pwsh
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+         Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/logistics/scripts/modules/utility/cross-platform.psm1"
+         if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") {
+              Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
+         }
+
+          # using WebClient is faster then Invoke-WebRequest but shows no progress
+          $sourceUrl = ' https://github.com/microsoft/artifacts-credprovider/releases/download/v1.0.0/Microsoft.NuGet.CredentialProvider.zip'
+          $fileName = 'Microsoft.NuGet.CredentialProvider.zip'
+          Write-host "Downloading file from $sourceUrl..."
+          $webClient = New-Object System.Net.WebClient
+          $webClient.DownloadFile($sourceUrl, "$env:temp/$fileName")
+
+          Write-host "Download complete." 
+
+          if (-not (Test-Path "$env:temp/$fileName")) {
+              Write-Warning "Microsoft.NuGet.CredentialProvider file '$fileName' not found."
+              exit 0
+          }
+
+          $packageFolder = "$env:temp/Microsoft.NuGet.CredentialProvider/"
+
+          if ($fileName.EndsWith('.zip')) {
+              Write-host "Extracting $fileName..."
+              $zipFilePath = "$env:temp/$fileName"
+              if (Test-Path $zipFilePath) { Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
+              Copy-Item -Path $packageFolder\* -Destination "$env:UserProfile/.nuget/" -Recurse -Force
+              Write-Host "Extracted to: $env:UserProfile\.nuget\plugins\" -ForegroundColor Green
+          }
+      shell: pwsh     
     - name: publish
       working-directory: ./Ed-Fi-Extensions/
       shell: pwsh

--- a/.github/workflows/Packages - EdFi.Ods.Extensions.Sample.yml
+++ b/.github/workflows/Packages - EdFi.Ods.Extensions.Sample.yml
@@ -83,8 +83,37 @@ jobs:
         .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -PackageName "EdFi.Suite3.Ods.Extensions.Sample" -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-Extensions/Extensions/EdFi.Ods.Extensions.Sample/EdFi.Ods.Extensions.Sample.nuspec"
       shell: pwsh
     - name: Install-credential-handler
-      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
-      shell: pwsh
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+         Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/logistics/scripts/modules/utility/cross-platform.psm1"
+         if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") {
+              Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
+         }
+
+          # using WebClient is faster then Invoke-WebRequest but shows no progress
+          $sourceUrl = ' https://github.com/microsoft/artifacts-credprovider/releases/download/v1.0.0/Microsoft.NuGet.CredentialProvider.zip'
+          $fileName = 'Microsoft.NuGet.CredentialProvider.zip'
+          Write-host "Downloading file from $sourceUrl..."
+          $webClient = New-Object System.Net.WebClient
+          $webClient.DownloadFile($sourceUrl, "$env:temp/$fileName")
+
+          Write-host "Download complete." 
+
+          if (-not (Test-Path "$env:temp/$fileName")) {
+              Write-Warning "Microsoft.NuGet.CredentialProvider file '$fileName' not found."
+              exit 0
+          }
+
+          $packageFolder = "$env:temp/Microsoft.NuGet.CredentialProvider/"
+
+          if ($fileName.EndsWith('.zip')) {
+              Write-host "Extracting $fileName..."
+              $zipFilePath = "$env:temp/$fileName"
+              if (Test-Path $zipFilePath) { Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
+              Copy-Item -Path $packageFolder\* -Destination "$env:UserProfile/.nuget/" -Recurse -Force
+              Write-Host "Extracted to: $env:UserProfile\.nuget\plugins\" -ForegroundColor Green
+          }
+      shell: pwsh     
     - name: publish
       working-directory: ./Ed-Fi-Extensions/
       shell: pwsh

--- a/.github/workflows/Packages - EdFi.Ods.Extensions.TPDM.yml
+++ b/.github/workflows/Packages - EdFi.Ods.Extensions.TPDM.yml
@@ -83,8 +83,37 @@ jobs:
       run: |
         .\build.githubactions.ps1 pack -Configuration ${{ env.CONFIGURATION }} -InformationalVersion ${{ env.INFORMATIONAL_VERSION}} -BuildCounter ${{ github.run_number }} -BuildIncrementer ${{env.BUILD_INCREMENTER}} -PackageName "EdFi.Suite3.Ods.Extensions.TPDM.Core.1.1.0" -NuspecFilePath "$env:GITHUB_WORKSPACE/Ed-Fi-Extensions/Extensions/EdFi.Ods.Extensions.TPDM/EdFi.Ods.Extensions.TPDM.nuspec"
     - name: Install-credential-handler
-      run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
-      shell: pwsh        
+      working-directory: ./Ed-Fi-ODS-Implementation/
+      run: |
+         Import-Module -Force -Scope Global "$env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/logistics/scripts/modules/utility/cross-platform.psm1"
+         if (Get-IsWindows -and -not Get-InstalledModule | Where-Object -Property Name -eq "7Zip4Powershell") {
+              Install-Module -Force -Scope CurrentUser -Name 7Zip4Powershell
+         }
+
+          # using WebClient is faster then Invoke-WebRequest but shows no progress
+          $sourceUrl = ' https://github.com/microsoft/artifacts-credprovider/releases/download/v1.0.0/Microsoft.NuGet.CredentialProvider.zip'
+          $fileName = 'Microsoft.NuGet.CredentialProvider.zip'
+          Write-host "Downloading file from $sourceUrl..."
+          $webClient = New-Object System.Net.WebClient
+          $webClient.DownloadFile($sourceUrl, "$env:temp/$fileName")
+
+          Write-host "Download complete." 
+
+          if (-not (Test-Path "$env:temp/$fileName")) {
+              Write-Warning "Microsoft.NuGet.CredentialProvider file '$fileName' not found."
+              exit 0
+          }
+
+          $packageFolder = "$env:temp/Microsoft.NuGet.CredentialProvider/"
+
+          if ($fileName.EndsWith('.zip')) {
+              Write-host "Extracting $fileName..."
+              $zipFilePath = "$env:temp/$fileName"
+              if (Test-Path $zipFilePath) { Expand-Archive -Force -Path $zipFilePath -DestinationPath $packageFolder }
+              Copy-Item -Path $packageFolder\* -Destination "$env:UserProfile/.nuget/" -Recurse -Force
+              Write-Host "Extracted to: $env:UserProfile\.nuget\plugins\" -ForegroundColor Green
+          }
+      shell: pwsh     
     - name: publish
       working-directory: ./Ed-Fi-Extensions/   
       shell: pwsh


### PR DESCRIPTION


build error is there  https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/actions/runs/3754286464/jobs/6378373834#step:14:22 in Install-credential-handler step .so https://github.com/Microsoft/artifacts-credprovider#manual-installation-on-windows - Manual Manual installation on Windows
 of Microsoft.NuGet.CredentialProvider.zip added