### PR TITLE
[ODS-6842] Set working-directory on tool-install step

### DIFF
--- a/.github/workflows/Pkg EdFi.Ods.Extensions.Homograph.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Extensions.Homograph.yml
@@ -95,6 +95,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-    
     - name: Run CodeGen
+      working-directory: ./Ed-Fi-Extensions/
       run: |
           $ErrorActionPreference = 'Stop'
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1

--- a/.github/workflows/Pkg EdFi.Ods.Extensions.Sample.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Extensions.Sample.yml
@@ -95,6 +95,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Run CodeGen
+      working-directory: ./Ed-Fi-Extensions/
       run: |
           $ErrorActionPreference = 'Stop'
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1

--- a/.github/workflows/Pkg EdFi.Ods.Extensions.SampleStudentTranscript.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Extensions.SampleStudentTranscript.yml
@@ -95,6 +95,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
     - name: Run CodeGen
+      working-directory: ./Ed-Fi-Extensions/
       run: |
           $ErrorActionPreference = 'Stop'
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1

--- a/.github/workflows/Pkg EdFi.Ods.Extensions.TPDM.yml
+++ b/.github/workflows/Pkg EdFi.Ods.Extensions.TPDM.yml
@@ -109,6 +109,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-  
     - name: Run CodeGen
+      working-directory: ./Ed-Fi-Extensions/
       run: |
           $ErrorActionPreference = 'Stop'
           . $env:GITHUB_WORKSPACE/Ed-Fi-ODS-Implementation/Initialize-PowershellForDevelopment.ps1


### PR DESCRIPTION
Add working-directory: ./Ed-Fi-Extensions/ to the CodeGen  step so the repository NuGet.Config (Azure feed + EdFi. packageSourceMapping) is on the discovery path, matching the other steps in these workflows.